### PR TITLE
NSDS-1951: Refactor to auto build oraclelinux and centos7 docker images

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -72,7 +72,7 @@ site_pp=$mod_dir/site.pp
 
 # check that module is here; if not, export it
 if [ ! -d $mod_dir ]; then
-  $git_cmd clone --single-branch -b $BRANCH $git_loc $mod_dir
+  $git_cmd clone --single-branch -b $BRANCH $git_loc $mod_dir --depth 1
 fi
 
 

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 
+if [ "$#" -ne 3 ]; then
+  echo "Usage: $0 <github org> <branch> <base branch>"
+  echo "e.g.: $0 hysds master master"
+  echo "e.g.: $0 hysds python2 develop"
+  echo "e.g.: $0 pymonger python3 develop"
+  exit 1
+fi
+ORG=$1
+BRANCH=$2
+BASE_BRANCH=$3
+
 mods_dir=/etc/puppet/modules
+mkdir -p $mods_dir
 cd $mods_dir
 
 ##########################################
@@ -54,13 +66,13 @@ fi
 # export mysql puppet module
 ##########################################
 
-git_loc="${git_url}/hysds/puppet-mysql"
+git_loc="${git_url}/${ORG}/puppet-mysql"
 mod_dir=$mods_dir/mysql
 site_pp=$mod_dir/site.pp
 
 # check that module is here; if not, export it
 if [ ! -d $mod_dir ]; then
-  $git_cmd clone $git_loc $mod_dir
+  $git_cmd clone --single-branch -b $BRANCH $git_loc $mod_dir
 fi
 
 
@@ -68,4 +80,10 @@ fi
 # apply
 ##########################################
 
-$puppet_cmd apply $site_pp
+PUPPET_EXIT_CODE=0
+$puppet_cmd apply --detailed-exitcodes $site_pp || PUPPET_EXIT_CODE=$?
+if [[ ("$PUPPET_EXIT_CODE" -ne 0 ) && ("$PUPPET_EXIT_CODE" -ne 2) ]]; then
+  echo "Puppet failed to run cleanly."
+  exit 1
+fi
+exit 0

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,8 +12,8 @@ class mysql {
     'mariadb-server': ensure => installed;
     'mariadb': ensure => installed;
     'mariadb-devel': ensure => installed;
-    'mariadb-libs': ensure => installed;
-    'mysql-connector-python': ensure => installed;
+    'mysql-libs': ensure => installed;
+    'python3-mysqlclient': ensure => installed;
   }
 
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,8 +12,8 @@ class mysql {
     'mariadb-server': ensure => installed;
     'mariadb': ensure => installed;
     'mariadb-devel': ensure => installed;
-    'mysql-libs': ensure => installed;
-    'python3-mysqlclient': ensure => installed;
+    'mariadb-libs': ensure => installed;
+    'mysql-connector-python': ensure => installed;
   }
 
 


### PR DESCRIPTION
Updated the install.sh script, which will allow us to build oraclelinux and centos7 docker images automatically.